### PR TITLE
applied automake-subdirs.patch from Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.65)
-AC_INIT([Gummi], [svn800], [alexvandermey@gmail.com], [gummi], [https://github.com/alexandervdm/gummi])
-AM_INIT_AUTOMAKE([foreign -Wall -Werror])
+AC_INIT([Gummi], [0.6.5], [alexvandermey@gmail.com], [gummi], [http://gummi.midnightcoding.org/])
+AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])
 
 GETTEXT_PACKAGE=gummi
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [The gettext domain])

--- a/data/misc/gummi.desktop.in
+++ b/data/misc/gummi.desktop.in
@@ -8,5 +8,6 @@ Icon=@PACKAGE@
 Terminal=false
 Type=Application
 Categories=Office;
+Keywords=latex;editor;
 StartupNotify=true
 MimeType=text/x-tex;


### PR DESCRIPTION
Description: automake1.14 warns about 'subdir-objects' not set together with -Werror this leads to a build failure
Bug: http://bugs.debian.org/725534
