### PR TITLE
Build fixes for Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,10 @@ if test "$spellcheck" = yes; then
 fi
 
 # Add explicit linking flags
-GUI_LIBS="$GUI_LIBS -pthread -lm -lz -lrt"
+GUI_LIBS="$GUI_LIBS -pthread -lm -lz"
+AC_CHECK_LIB(rt, clock_gettime, [
+    GUI_LIBS="$GUI_LIBS -lrt"
+])
 
 # Checks for header files.
 AC_CHECK_HEADERS([libintl.h locale.h netdb.h stdlib.h string.h sys/socket.h sys/time.h unistd.h fcntl.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS = gummi
 AM_CFLAGS = $(GUI_CFLAGS) \
-	    -export-dynamic -Wall -O2 \
+	    -Wl,-export-dynamic -Wall -O2 \
 	    -DGUMMI_LIBS=\"$(libdir)/$(PACKAGE)\" \
 	    -DGUMMI_DATA=\"$(datadir)/$(PACKAGE)\" \
 	    -DGUMMI_LOCALES=\"$(datadir)/locale\"


### PR DESCRIPTION
I needed these two fixes to be able to build gummi on Mac OS X for [pkgsrc](http://www.pkgsrc.org).
