### PR TITLE
Feature/Add feature to refuse saving when file has been changed externally (issue #16)

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -32,6 +32,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include <gtksourceview/gtksourcebuffer.h>
 #include <gtksourceview/gtksourceiter.h>
@@ -222,6 +223,11 @@ void editor_fileinfo_update (GuEditor* ec, const gchar* filename) {
         ec->workfile = g_strdup_printf ("%s.swp", ec->basename);
         ec->pdffile =  g_strdup_printf ("%s%c.%s.pdf", C_TMPDIR,
                                        G_DIR_SEPARATOR, base);
+        // Get last modified time
+        struct stat attr;
+        stat(fname, &attr);
+        ec->last_modtime = attr.st_mtime;
+
         g_free (fname);
         g_free (base);
         g_free (dir);

--- a/src/editor.h
+++ b/src/editor.h
@@ -59,6 +59,7 @@ struct _GuEditor {
     gchar* workfile;
     gchar* bibfile;
     gchar* projfile;
+    time_t last_modtime;
 
     /* GUI related members */
     GtkSourceView* view;

--- a/src/gui/gui-main.c
+++ b/src/gui/gui-main.c
@@ -348,8 +348,6 @@ void gui_set_window_title (const gchar* filename, const gchar* text) {
     g_free (title);
 }
 
-
-
 void on_recovery_infobar_response (GtkInfoBar* bar, gint res, gpointer filename) {
     gchar* prev_workfile = iofunctions_get_swapfile (filename);
 
@@ -433,8 +431,18 @@ void gui_save_file (GuTabContext* tab, gboolean saveas) {
     stat(filename, &attr);
     lastmod = difftime(tab->editor->last_modtime, attr.st_mtime);
     if (lastmod != 0.0) {
-        ret = utils_yes_no_dialog( ("This file has been modified externally, do you want to continue? (any external changes will be lost)") );
-        if (GTK_RESPONSE_YES != ret) goto cleanup;
+        /* Ask the user whether he want to save or reload */
+        ret = utils_save_reload_dialog( ("The content of the file has been changed externally. Saving will remove any external modifications.") );
+        if (ret == GTK_RESPONSE_YES) {
+            tabmanager_set_content(A_LOAD, filename, NULL);
+            /* Resets modtime */
+            stat(filename, &attr);
+            tab->editor->last_modtime = attr.st_mtime;
+            goto cleanup;
+        } else if (ret != GTK_RESPONSE_NO) {
+            /* cancel means: do nothing */
+            goto cleanup;
+        }
     }
 
     focus = gtk_window_get_focus (gummi_get_gui ()->mainwindow);
@@ -452,7 +460,7 @@ void gui_save_file (GuTabContext* tab, gboolean saveas) {
     gui_set_filename_display (tab, TRUE, TRUE);
     gtk_widget_grab_focus (GTK_WIDGET (tab->editor->view));
 
-    /* Resets the modtime we have */
+    /* Resets modtime */
     stat(filename, &attr);
     tab->editor->last_modtime = attr.st_mtime;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -142,6 +142,26 @@ void slog (gint level, const gchar *fmt, ...) {
         exit (1);
 }
 
+gint utils_save_reload_dialog (const gchar* message) {
+    GtkWidget* dialog;
+    gint ret = 0;
+
+    g_return_val_if_fail (message != NULL, 0);
+
+    dialog = gtk_message_dialog_new (parent,
+                 GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                 GTK_MESSAGE_QUESTION,
+                 GTK_BUTTONS_NONE,
+                 "%s", message);
+    gtk_dialog_add_buttons(dialog, "Reload", GTK_RESPONSE_YES, "Save", GTK_RESPONSE_NO, NULL);
+
+    gtk_window_set_title (GTK_WINDOW (dialog), _("Confirmation"));
+    ret = gtk_dialog_run (GTK_DIALOG (dialog));
+    gtk_widget_destroy (dialog);
+
+    return ret;
+}
+
 gint utils_yes_no_dialog (const gchar* message) {
     GtkWidget* dialog;
     gint ret = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -117,6 +117,7 @@ gboolean in_debug_mode();
 void slog_set_gui_parent (GtkWindow* p);
 void slog (gint level, const gchar *fmt, ...);
 gint utils_yes_no_dialog (const gchar* message);
+gint utils_save_reload_dialog (const gchar* message);
 gboolean utils_path_exists (const gchar* path);
 gboolean utils_set_file_contents (const gchar *filename, const gchar *text,
         gssize length);


### PR DESCRIPTION
Issue this PR refers to: https://github.com/alexandervdm/gummi/issues/16

This was bothering me as well since sometimes I work on two different computers that I sync with dropbox and didn't want to lose any work. 

With this modification, if gummi detects the modification date on the file has changed it will show a dialog asking whether the user want to reload the file (and lose any changes to it) or save it (and overwrite any changes made externally). This is a similar behaviour that can be found in other programs.

I hope it is useful!
