### PR TITLE
Use lang instead of hardcoded "en" for gtkspell_new_attach

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -335,7 +335,7 @@ void editor_activate_spellchecking (GuEditor* ec, gboolean status) {
     GError* err2 = NULL;
     GtkSpell* spell = 0;
     if (status) {
-        if (! (spell = gtkspell_new_attach (ec_view, "en", &err))) {
+        if (! (spell = gtkspell_new_attach (ec_view, lang, &err))) {
             slog (L_ERROR, "gtkspell_new_attach (): %s\n", err->message);
             g_error_free (err);
         }


### PR DESCRIPTION
If the "en" language files are not installed, gtkspell always fail to initialize.
After this commit it is possible to use aspell with any language without having "en" language.

I tested the following scenarios :
- Using the default config of spell_language = None
- Using a non-present language in config
- Using a functional language
- Changing language in GUI
- Enabling/disabling spell check in GUI