### PR TITLE
Fixes #48: 2011 bug 252 does not seem to make icons disappear anymore

### DIFF
--- a/src/gui/gui-main.c
+++ b/src/gui/gui-main.c
@@ -956,11 +956,11 @@ void gui_buildlog_set_text (const gchar *message) {
         GtkTextIter iter;
         gtk_text_buffer_set_text (gui->errorbuff, message, -1);
         gtk_text_buffer_get_end_iter (gui->errorbuff, &iter);
-		// The following lines are commented out, as they seem to cause
+		// The following lines were commented out, as they seem to cause
 		// Bug #252.
-        //GtkTextMark *mark = gtk_text_buffer_create_mark(gui->errorbuff, NULL, &iter, FALSE);
-        //gtk_text_view_scroll_to_mark (gui->errorview, mark, 0.25, FALSE, 0, 0);
-        //gtk_text_view_scroll_to_iter (gui->errorview, &iter, 0.25, FALSE, 0, 0);
+        GtkTextMark *mark = gtk_text_buffer_create_mark(gui->errorbuff, NULL, &iter, FALSE);
+        gtk_text_view_scroll_to_mark (gui->errorview, mark, 0.25, FALSE, 0, 0);
+        gtk_text_view_scroll_to_iter (gui->errorview, &iter, 0.25, FALSE, 0, 0);
     }
 }
 


### PR DESCRIPTION
Three lines providing the expected behavior were commented out since, for what I was able to gather from Wayback Machine, 2011 due to a bug making menu icons disappear.