### PR TITLE
Add rudimentary LuaTeX support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ ltmain.sh
 
 # glade tmp files
 data/ui/*.glade~
+
+# VSCode workspace configurations
+.vscode

--- a/data/ui/prefs.glade
+++ b/data/ui/prefs.glade
@@ -1168,6 +1168,50 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkHBox" id="hbox9">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label7">
+                                <property name="width_request">12</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">   </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkRadioButton" id="typ_lualatex">
+                                <property name="label" translatable="yes">TeXLive with LuaTeX</property>
+                                <property name="visible">True</property>
+                                <property name="sensitive">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="focus_on_click">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">This program was not found on your system.</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="group">typ_pdflatex</property>
+                                <signal name="toggled" handler="on_typ_lualatex_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkHBox" id="hbox11">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1208,7 +1252,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -1252,7 +1296,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>
@@ -1980,7 +2024,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox9">
+                      <object class="GtkHBox" id="hbox10">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -2056,7 +2100,7 @@
                         <property name="can_focus">False</property>
                         <property name="spacing">3</property>
                         <child>
-                          <object class="GtkHBox" id="hbox10">
+                          <object class="GtkHBox" id="hbox27">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -2114,7 +2158,7 @@
               </packing>
             </child>
             <child type="tab">
-              <object class="GtkLabel" id="label7">
+              <object class="GtkLabel" id="label55">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Miscellaneous</property>

--- a/src/compile/texlive.c
+++ b/src/compile/texlive.c
@@ -39,6 +39,7 @@
 
 gboolean pdf_detected = FALSE;
 gboolean xel_detected = FALSE;
+gboolean lua_detected = FALSE;
 
 /* All the functions for "pure" building with texlive only tools */
 
@@ -61,11 +62,17 @@ int texlive_init (void) {
               external_version (C_XELATEX));
         xel_detected = TRUE;
     }
+
+    if (external_exists (C_LUALATEX)) {
+        slog (L_INFO, "Typesetter detected: %s\n",
+              external_version (C_LUALATEX));
+        lua_detected = TRUE;
+    }
     return texversion;
 }
 
 gboolean texlive_active (void) {
-    if (pdflatex_active() || xelatex_active()) {
+    if (pdflatex_active() || xelatex_active() || lualatex_active()) {
         return TRUE;
     }
     return FALSE;
@@ -85,12 +92,23 @@ gboolean xelatex_active (void) {
     return FALSE;
 }
 
+gboolean lualatex_active (void) {
+    if (config_value_as_str_equals ("Compile", "typesetter", "lualatex")) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
 gboolean pdflatex_detected (void) {
     return pdf_detected;
 }
 
 gboolean xelatex_detected (void) {
     return xel_detected;
+}
+
+gboolean lualatex_detected (void) {
+    return lua_detected;
 }
 
 gchar* texlive_get_command (const gchar* method, gchar* workfile, gchar* basename) {
@@ -102,6 +120,7 @@ gchar* texlive_get_command (const gchar* method, gchar* workfile, gchar* basenam
     gchar *texcmd = NULL;
 
     if (pdflatex_active()) typesetter = C_PDFLATEX;
+    else if (lualatex_active()) typesetter = C_LUALATEX;
     else typesetter = C_XELATEX;
 
     gchar *flags = texlive_get_flags("texpdf");

--- a/src/compile/texlive.h
+++ b/src/compile/texlive.h
@@ -37,9 +37,11 @@ int texlive_init (void);
 gboolean texlive_active (void);
 gboolean pdflatex_active (void);
 gboolean xelatex_active (void);
+gboolean lualatex_active (void);
 
 gboolean pdflatex_detected (void);
 gboolean xelatex_detected (void);
+gboolean lualatex_detected (void);
 
 gchar* texlive_get_command (const gchar* method, gchar* workfile, gchar* basename);
 gchar* texlive_get_flags (const gchar *method);

--- a/src/constants.h
+++ b/src/constants.h
@@ -122,6 +122,7 @@
 #define C_LATEX "latex"
 #define C_PDFLATEX "pdflatex"
 #define C_XELATEX "xelatex"
+#define C_LUALATEX "lualatex"
 #define C_RUBBER "rubber"
 #define C_LATEXMK "latexmk"
 

--- a/src/external.c
+++ b/src/external.c
@@ -94,6 +94,8 @@ gchar* external_version (const gchar* program) {
     /* pdfTeX 3.1415926-1.40.10 (TeX Live 2009)
        pdfTeX 3.1415926-1.40.11-2.2 (TeX Live 2010)
        pdfTeX 3.1415926-2.3-1.40.12 (TeX Live 2011)
+
+       This is LuaTeX, Version 1.10.0 (TeX Live 2019/Debian)
     */
     if (STR_EQU (program, C_RUBBER)) {
         result = version_rubber (result);

--- a/src/gui/gui-prefs.c
+++ b/src/gui/gui-prefs.c
@@ -117,6 +117,8 @@ GuPrefsGui* prefsgui_init (GtkWindow* mainwindow) {
         GTK_TOGGLE_BUTTON (gtk_builder_get_object (builder, "typ_pdflatex"));
     p->typ_xelatex =
         GTK_TOGGLE_BUTTON (gtk_builder_get_object (builder, "typ_xelatex"));
+    p->typ_lualatex =
+        GTK_TOGGLE_BUTTON (gtk_builder_get_object (builder, "typ_lualatex"));
     p->typ_rubber =
         GTK_TOGGLE_BUTTON (gtk_builder_get_object (builder, "typ_rubber"));
     p->typ_latexmk =
@@ -288,6 +290,13 @@ static void set_tab_compilation_settings (GuPrefsGui* prefs) {
             gtk_toggle_button_set_active (prefs->typ_xelatex, TRUE);
         gtk_widget_set_sensitive (GTK_WIDGET(prefs->typ_xelatex), TRUE);
         gtk_widget_set_tooltip_text (GTK_WIDGET(prefs->typ_xelatex), "");
+    }
+
+    if (lualatex_detected()) {
+        if (lualatex_active())
+            gtk_toggle_button_set_active (prefs->typ_lualatex, TRUE);
+        gtk_widget_set_sensitive (GTK_WIDGET(prefs->typ_lualatex), TRUE);
+        gtk_widget_set_tooltip_text (GTK_WIDGET(prefs->typ_lualatex), "");
     }
 
     if (rubber_detected()) {
@@ -675,6 +684,14 @@ G_MODULE_EXPORT
 void on_typ_xelatex_toggled (GtkToggleButton* widget, void* user) {
     if (gtk_toggle_button_get_active (widget)) {
         config_set_string ("Compile", "typesetter", "xelatex");
+        typesetter_setup ();
+    }
+}
+
+G_MODULE_EXPORT
+void on_typ_lualatex_toggled (GtkToggleButton* widget, void* user) {
+    if (gtk_toggle_button_get_active (widget)) {
+        config_set_string ("Compile", "typesetter", "lualatex");
         typesetter_setup ();
     }
 }

--- a/src/gui/gui-prefs.h
+++ b/src/gui/gui-prefs.h
@@ -64,6 +64,7 @@ struct _GuPrefsGui {
 
     GtkToggleButton* typ_pdflatex;
     GtkToggleButton* typ_xelatex;
+    GtkToggleButton* typ_lualatex;
     GtkToggleButton* typ_rubber;
     GtkToggleButton* typ_latexmk;
 


### PR DESCRIPTION
Adds TeXLive with LuaTeX as a compiler option. This should fix #91. Also includes the .vscode configuration directory in .gitignore to avoid accidents.