### PR TITLE
rpmbuild fixes for CentOS-8

### DIFF
--- a/packages/gummi.spec
+++ b/packages/gummi.spec
@@ -1,0 +1,52 @@
+Name:           gummi
+Version:        0.8.1
+Release:        1%{?dist}
+Summary:        A simple LaTeX editor
+
+License:        MIT
+URL:            https://github.com/alexandervdm/gummi
+Source0:        https://github.com/alexandervdm/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gtk3-devel
+BuildRequires:  gtksourceview3-devel
+BuildRequires:  poppler-glib-devel
+BuildRequires:  gtkspell3-devel
+BuildRequires:  intltool
+BuildRequires:  desktop-file-utils
+BuildRequires:  texlive-lib-devel
+
+Requires:       texlive-latex
+
+%description
+Gummi is a LaTeX editor written in the C programming language using the
+GTK+ interface toolkit. It was designed with simplicity and the novice
+user in mind, but also offers features that speak to the more advanced user.
+
+%prep
+%setup -q
+
+%build
+%configure
+make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot} INSTALL="install -p"
+%find_lang %{name}
+desktop-file-install                                 \
+    --remove-key="Version"                           \
+    --add-category="Publishing;"                     \
+    --dir=%{buildroot}%{_datadir}/applications       \
+    %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+%files -f %{name}.lang
+%doc AUTHORS ChangeLog COPYING NEWS
+%{_mandir}/man*/*.1*
+%{_bindir}/%{name}
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.png
+%{_datadir}/%{name}/
+%{_libdir}/%{name}/
+
+%changelog
+* Tue Mar 3 2020 Adam Boutcher <adam.j.boutcher@durham.ac.uk> - 0.8.1
+- Build for CentOS8 - Please see GitHub for true Changelog

--- a/src/gui/gui-preview.c
+++ b/src/gui/gui-preview.c
@@ -56,14 +56,6 @@
 #   include "config.h"
 #endif
 
-// compatibility fixes for libsynctex (>=1.16 && <=2.00):
-#ifdef USE_SYNCTEX1
-  typedef synctex_scanner_t synctex_scanner_p;
-  typedef synctex_node_t synctex_node_p;
-  #define synctex_display_query(scanner, file, line, column, page) synctex_display_query(scanner, file, line, column)
-  #define synctex_scanner_next_result(scanner) synctex_next_result(scanner)
-#endif
-
 #define page_inner(pc,i) (((pc)->pages + (i))->inner)
 #define page_outer(pc,i) (((pc)->pages + (i))->outer)
 


### PR DESCRIPTION
These are the channges I made to build gummi on CentOS 8.

FYI you need both EPEL and PowerTools repos enabled.
For anyone lazy the x86_64 rpms can be found at the [IPPP Mirror](https://mirror.dur.scotgrid.ac.uk/) . Direct: [gummi-0-8.1-x86_64.rpm](https://mirror.dur.scotgrid.ac.uk/repos/phyip3.dur.ac.uk/centos/8/x86_64/gummi-0.8.1-8.el8.x86_64.rpm) and [gummi-debuginfo-0.8.1-x86_64.rpm](https://mirror.dur.scotgrid.ac.uk/repos/phyip3.dur.ac.uk/centos/8/x86_64/gummi-debuginfo-0.8.1-8.el8.x86_64.rpm)