### PR TITLE
ensure compile error doesn't lose preview position

### DIFF
--- a/src/gui/gui-preview.c
+++ b/src/gui/gui-preview.c
@@ -1455,7 +1455,7 @@ void previewgui_scroll_to_xy (GuPreviewGui* pc, gdouble x, gdouble y) {
 
 void previewgui_save_position (GuPreviewGui* pc) {
     //L_F_DEBUG;
-    if (g_active_tab != NULL) {
+    if (g_active_tab != NULL && !pc->errormode) {
         g_active_tab->scroll_x = gtk_adjustment_get_value (pc->hadj);
         g_active_tab->scroll_y = gtk_adjustment_get_value (pc->vadj);
         block_handlers_current_page(pc);


### PR DESCRIPTION
When the preview pane is displaying a compile error, calls to `previewgui_save_position` would previously reset the saved position to 0/0, and thus the position in the preview would be lost when the error was cleared. This change prevents calls to `previewgui_save_position` from having any effect when an error is being displayed.