### PR TITLE
Load external changes

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -305,6 +305,19 @@ void editor_fileinfo_cleanup (GuEditor* ec) {
     ec->basename = NULL;
 }
 
+void editor_modtime_update (GuEditor* ec) {
+    struct stat attr;
+    stat(ec->filename, &attr);
+    ec->last_modtime = attr.st_mtime;
+}
+
+gboolean editor_externally_modified (GuEditor* ec) {
+    struct stat attr;
+    stat(ec->filename, &attr);
+    double mismatch = difftime (ec->last_modtime, attr.st_mtime);
+    return mismatch != 0.0 && ec->last_modtime != 0.0;
+}
+
 void editor_sourceview_config (GuEditor* ec) {
     GtkWrapMode wrapmode = 0;
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -54,6 +54,7 @@ struct _GuEditor {
     gchar* bibfile;
     gchar* projfile;
     time_t last_modtime;
+    time_t last_external_modtime;
 
     /* GUI related members */
     GtkSourceView* view;
@@ -78,8 +79,8 @@ GuEditor* editor_new (GuMotion* mc);
 void editor_fileinfo_update (GuEditor* ec, const gchar* filename);
 gboolean editor_fileinfo_update_biblio (GuEditor* ec,  const gchar* filename);
 void editor_fileinfo_cleanup (GuEditor* ec);
-void editor_modtime_update (GuEditor* ec);
-gboolean editor_externally_modified (GuEditor* ec);
+void editor_modtime_update (GuEditor* ec, gboolean external);
+gboolean editor_externally_modified (GuEditor* ec, gboolean since_loaded);
 void editor_destroy (GuEditor* ec);
 void editor_sourceview_config (GuEditor* ec);
 void editor_activate_spellchecking (GuEditor* ec, gboolean status);

--- a/src/editor.h
+++ b/src/editor.h
@@ -76,8 +76,10 @@ struct _GuEditor {
 
 GuEditor* editor_new (GuMotion* mc);
 void editor_fileinfo_update (GuEditor* ec, const gchar* filename);
-void editor_fileinfo_cleanup (GuEditor* ec);
 gboolean editor_fileinfo_update_biblio (GuEditor* ec,  const gchar* filename);
+void editor_fileinfo_cleanup (GuEditor* ec);
+void editor_modtime_update (GuEditor* ec);
+gboolean editor_externally_modified (GuEditor* ec);
 void editor_destroy (GuEditor* ec);
 void editor_sourceview_config (GuEditor* ec);
 void editor_activate_spellchecking (GuEditor* ec, gboolean status);

--- a/src/gui/gui-main.c
+++ b/src/gui/gui-main.c
@@ -453,19 +453,15 @@ void gui_save_file (GuTabContext* tab, gboolean saveas) {
 
     if (!new && editor_externally_modified (tab->editor, TRUE)) {
         // ask the user whether he want to save or reload
-        ret = utils_save_reload_dialog (
+        ret = utils_save_confirmation_dialog (
                 _("The content of the file has been changed externally. "
                   "Saving will remove any external modifications."));
-        if (ret == GTK_RESPONSE_YES) {
-            // `!new` should guarantee that `filename` matches
-            // `tab->editor->filename` here
-            tabmanager_set_content (A_LOAD, tab->editor->filename, NULL);
-            editor_modtime_update (tab->editor, TRUE);
-            goto cleanup;
-        } else if (ret != GTK_RESPONSE_NO) {
-            // cancel means: do nothing
-            goto cleanup;
-        }
+        // clicking "Cancel" (which returns GTK_RESPONSE_NO) and pressing escape
+        // (which treturns something else) should both cancel the save. no
+        // cleanup is required, becaue `pdfname` hasn't had a chance to be
+        // allocated yet, and `!new` should guarantee that `filename` wasn't
+        // allocated earlier
+        if (ret != GTK_RESPONSE_YES) return;
     }
 
     focus = gtk_window_get_focus (gummi_get_gui ()->mainwindow);

--- a/src/gui/gui-main.c
+++ b/src/gui/gui-main.c
@@ -333,6 +333,14 @@ void gui_set_window_title (const gchar* filename, const gchar* text) {
     g_free (title);
 }
 
+gboolean on_focus_in_view (GtkWidget* widget, GdkEventFocus* event, GuTabContext* tab) {
+    slog (L_WARNING, "Focused in '%s' view.\n", tab->editor->filename);
+    if (editor_externally_modified (tab->editor, FALSE)) {
+        gui_external_changes_enable (tab);
+    }
+    return GDK_EVENT_PROPAGATE;
+}
+
 void on_reload_infobar_response (GtkInfoBar* bar, gint res, gpointer data) {
     GuEditor* ec = data;
     gboolean reload = res == GTK_RESPONSE_YES;

--- a/src/gui/gui-main.h
+++ b/src/gui/gui-main.h
@@ -146,6 +146,7 @@ void on_bibreference_clicked (GtkTreeView* view, GtkTreePath* Path,
 void on_biblio_filter_changed (GtkWidget* widget, void* user);
 gboolean on_bibprogressbar_update (void* data);
 
+gboolean on_focus_in_view (GtkWidget* widget, GdkEventFocus* event, GuTabContext* tab);
 void on_reload_infobar_response (GtkInfoBar* bar, gint res, gpointer filename);
 void gui_external_changes_enable (GuTabContext* tab);
 /* void gui_external_changes_disable (GtkInfoBar *infobar); */ // would currently be identical to gui_external_changes_disable

--- a/src/gui/gui-main.h
+++ b/src/gui/gui-main.h
@@ -136,7 +136,6 @@ void on_button_template_open_clicked (GtkWidget* widget, void* user);
 void on_button_template_close_clicked (GtkWidget* widget, void* user);
 void on_template_rowitem_edited (GtkWidget* widget, gchar *path, gchar* filenm,
         void* user);
-void gui_recover_from_swapfile (const gchar* filename);
 void on_menu_autosync_toggled (GtkCheckMenuItem *menu_autosync, void* user);
 
 void on_button_biblio_compile_clicked (GtkWidget* widget, void* user);

--- a/src/gui/gui-main.h
+++ b/src/gui/gui-main.h
@@ -123,7 +123,8 @@ void gui_open_file (const gchar* filename);
 void gui_save_file (GuTabContext* tab, gboolean saveas);
 void gui_set_hastabs_sensitive (gboolean enable);
 
-void on_tab_notebook_switch_page (GtkNotebook *notebook, GtkWidget* nbpage, int pagenr, void* data);
+void on_tab_notebook_switch_page (GtkNotebook *notebook, GtkWidget* nbpage,
+        int pagenr, void* data);
 void on_tool_textstyle_bold_activate (GtkWidget* widget, void* user);
 void on_tool_textstyle_italic_activate (GtkWidget* widget, void* user);
 void on_tool_textstyle_underline_activate (GtkWidget* widget, void* user);
@@ -144,6 +145,10 @@ void on_bibreference_clicked (GtkTreeView* view, GtkTreePath* Path,
         GtkTreeViewColumn* column, void* user);
 void on_biblio_filter_changed (GtkWidget* widget, void* user);
 gboolean on_bibprogressbar_update (void* data);
+
+void on_reload_infobar_response (GtkInfoBar* bar, gint res, gpointer filename);
+void gui_external_changes_enable (GuTabContext* tab);
+/* void gui_external_changes_disable (GtkInfoBar *infobar); */ // would currently be identical to gui_external_changes_disable
 
 void on_recovery_infobar_response (GtkInfoBar* bar, gint res, gpointer filename);
 void gui_recovery_mode_enable (GuTabContext* tab, const gchar* filename);

--- a/src/gui/gui-tabmanager.c
+++ b/src/gui/gui-tabmanager.c
@@ -71,6 +71,8 @@ int tabmanagergui_create_page (GuTabContext* tc, GuEditor* editor) {
     gtk_box_pack_start (GTK_BOX (tp->editorbox), tp->infobar, FALSE, FALSE, 0);
     gtk_box_pack_end (GTK_BOX (tp->editorbox), tp->scrollw, TRUE, TRUE, 0);
 
+    g_signal_connect_after (editor->view, "focus-in-event", G_CALLBACK (on_focus_in_view), tc);
+
     pos = gtk_notebook_append_page (GTK_NOTEBOOK (g_tabnotebook),
                                     tp->editorbox, GTK_WIDGET (tp->labelbox));
 
@@ -156,6 +158,7 @@ gint tabmanagergui_replace_page (GuTabContext* tc, GuEditor* newec) {
     editor_destroy (g_active_editor);
     gtk_container_add (GTK_CONTAINER (tc->page->scrollw),
                        GTK_WIDGET (newec->view));
+    g_signal_connect_after (newec->view, "focus-in-event", G_CALLBACK (on_focus_in_view), tc);
     gtk_widget_show (GTK_WIDGET(newec->view));
 
     int pos = gtk_notebook_page_num (g_tabnotebook,

--- a/src/tabmanager.c
+++ b/src/tabmanager.c
@@ -107,6 +107,9 @@ void tabmanager_set_active_tab (int position) {
         g_active_tab = GU_TAB_CONTEXT (g_list_nth_data (g_tabs, position));
         g_active_editor =
             GU_TAB_CONTEXT (g_list_nth_data (g_tabs, position))->editor;
+        if (editor_externally_modified (g_active_editor, FALSE)) {
+            gui_external_changes_enable (g_active_tab);
+        }
     }
 }
 

--- a/src/tabmanager.c
+++ b/src/tabmanager.c
@@ -107,9 +107,6 @@ void tabmanager_set_active_tab (int position) {
         g_active_tab = GU_TAB_CONTEXT (g_list_nth_data (g_tabs, position));
         g_active_editor =
             GU_TAB_CONTEXT (g_list_nth_data (g_tabs, position))->editor;
-        if (editor_externally_modified (g_active_editor, FALSE)) {
-            gui_external_changes_enable (g_active_tab);
-        }
     }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -142,7 +142,7 @@ void slog (gint level, const gchar *fmt, ...) {
         exit (1);
 }
 
-gint utils_save_reload_dialog (const gchar* message) {
+gint utils_save_confirmation_dialog (const gchar* message) {
     GtkWidget* dialog;
     gint ret = 0;
 
@@ -153,7 +153,7 @@ gint utils_save_reload_dialog (const gchar* message) {
                  GTK_MESSAGE_QUESTION,
                  GTK_BUTTONS_NONE,
                  "%s", message);
-    gtk_dialog_add_buttons(GTK_DIALOG (dialog), "Reload", GTK_RESPONSE_YES, "Save", GTK_RESPONSE_NO, NULL);
+    gtk_dialog_add_buttons(GTK_DIALOG (dialog), "Cancel", GTK_RESPONSE_NO, "Save Anyway", GTK_RESPONSE_YES, NULL);
 
     gtk_window_set_title (GTK_WINDOW (dialog), _("Confirmation"));
     ret = gtk_dialog_run (GTK_DIALOG (dialog));

--- a/src/utils.h
+++ b/src/utils.h
@@ -117,7 +117,7 @@ gboolean in_debug_mode();
 void slog_set_gui_parent (GtkWindow* p);
 void slog (gint level, const gchar *fmt, ...);
 gint utils_yes_no_dialog (const gchar* message);
-gint utils_save_reload_dialog (const gchar* message);
+gint utils_save_confirmation_dialog (const gchar* message);
 gboolean utils_path_exists (const gchar* path);
 gboolean utils_uri_path_exists (const gchar* uri);
 gboolean utils_set_file_contents (const gchar *filename, const gchar *text, gssize length);


### PR DESCRIPTION
### What it does

This feature implements a gedit-style offer to load external changes, addressing issue alexandervdm#167. In the process, it also addresses issue alexandervdm#168. See https://github.com/alexandervdm/gummi/issues/167#issuecomment-1079944636.

### How it works

When a tab gains focus ([`on_focus_in_view`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/gui/gui-main.c#L336)), the interface checks whether the associated file has been changed externally ([`editor_externally_modified`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/editor.c#L316)). If so, the tab shows an info bar offering to reload the file ([`gui_external_changes_enable`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/gui/gui-main.c#L355)).

### To do

#### Short term

- Localize the info bar messages in [`utils_save_confirmation_dialog`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/utils.c#L145) and [`gui_external_changes_enable`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/gui/gui-main.c#L355).
- Remove the debug warning from [`on_focus_in_view`](https://github.com/Vectornaut/gummi/blob/cc3830c5ef9fef587c5573d1176bb3b4ea7f2211/src/gui/gui-main.c#L336).

#### Long term

- Generalize the info bar system so that Gummi can use info bars more consistently in the future. Right now, this feature co-opts the recovery mode info bar.
- Use the built-in `gtk_source_file_is_externally_modified`, like gedit does [here](https://github.com/GNOME/gedit/blob/fa587e033c97fac65dacdb3c9520635beca68fbc/gedit/gedit-document.c#L1325) and [here](https://github.com/GNOME/gedit/blob/b12398de45d9312c793eb4888c66eeea0a790d7b/gedit/gedit-tab.c#L1294), instead of the custom `last_external_modtime` system.